### PR TITLE
Make the template work out-of-the-box

### DIFF
--- a/{{ cookiecutter.repo_name }}/i18n/ksh.json
+++ b/{{ cookiecutter.repo_name }}/i18n/ksh.json
@@ -7,6 +7,6 @@
 	"{{ cookiecutter.i18n_prefix }}-desc": "Dat heh es e eijfach Beischpell för e Zohsazprojramm.",
 	"{{ cookiecutter.i18n_prefix }}-i18n-welcome": "Wellkumme bei de Övversäzonge för dat Beischpell för e Zohsazprojramm heh."{% if cookiecutter.integration_add_example_special_page == 'y' %},
 	"{{ cookiecutter.i18n_prefix }}-helloworld": "Hey Wält!",
-	"{{ cookiecutter.i18n_prefix }}-helloworld-intro": "Wellkumme op dä {{intspecialpage}} met „Hey Wält!“ vum Zohsazprojramm „<i lang=\"en\" xml:lang=\"en\" dir=\"ltr\" title=\"„E janz jewöhnlesch Beijschpell“\">{{ cookiecutter.repo_name }}</i>“.",
+	"{{ cookiecutter.i18n_prefix }}-helloworld-intro": "Wellkumme op dä \{\{intspecialpage\}\} met „Hey Wält!“ vum Zohsazprojramm „<i lang=\"en\" xml:lang=\"en\" dir=\"ltr\" title=\"„E janz jewöhnlesch Beijschpell“\">{{ cookiecutter.repo_name }}</i>“.",
 	"helloworld": "HalloWält"{% endif %}
 }

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.repo_name }}.i18n.magic.php
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.repo_name }}.i18n.magic.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Magic words of the {{ cookiecutter.repo_name }} extension
+ *
+ * @file
+ * @ingroup Extensions
+ */
+
+$magicWords = array();
+
+/** English (English) */
+$magicWords['en'] = array(
+   'something' => array( 0, 'something' ),
+);

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.repo_name }}.php
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.repo_name }}.php
@@ -5,6 +5,7 @@ if ( function_exists( 'wfLoadExtension' ) ) {
 	// Keep i18n globals so mergeMessageFileList.php doesn't break
 	$wgMessagesDirs['{{ cookiecutter.repo_name }}'] = __DIR__ . '/i18n';
 	{% if cookiecutter.integration_add_example_special_page == 'y' %}$wgExtensionMessagesFiles['{{ cookiecutter.repo_name }}Alias'] = __DIR__ . '/{{ cookiecutter.repo_name }}.i18n.alias.php';{% endif %}
+	$wgExtensionMessagesFiles['{{ cookiecutter.repo_name }}Magic'] = __DIR__ . '/{{ cookiecutter.repo_name }}.i18n.magic.php';
 	wfWarn(
 		'Deprecated PHP entry point used for {{ cookiecutter.repo_name }} extension. Please use wfLoadExtension ' .
 		'instead, see https://www.mediawiki.org/wiki/Extension_registration for more details.'


### PR DESCRIPTION
Dear Jonas,

thank you for your Cookiecutter template to create MediaWiki extensions.
This pull request should solve two bugs, that prevent your template from working out-of-the-box:
1. removes unknown variable `intspecialpage` from KSH translation
2. adds (english) magic word list to the extension template

As a comment to the first issue: I don't know which variable the author is referring to. As KSH is a dialect of german which - overall - is less popular, it seems valid to simply remove it.

Best,
Sebastian
